### PR TITLE
[TP-0045] Fix DELETE /api/characters/[id] FK constraint cascade

### DIFF
--- a/site/src/lib/db/character.repo.ts
+++ b/site/src/lib/db/character.repo.ts
@@ -110,8 +110,26 @@ class CharacterRepo {
 		);
 	}
 
-	public async delete({ id }: { id: number }) {
-		await (mysqlconnFn()).execute('DELETE FROM Characters WHERE Id = ?', [id]);
+	public async delete(id: number): Promise<void> {
+		const connection = mysqlconnFn();
+
+		const [versionRows] = await connection.execute(
+			`SELECT Id FROM Character_Versions WHERE Character = ?`,
+			[id]
+		);
+		const versionIds = (versionRows as any[]).map((r) => r.Id);
+
+		if (versionIds.length > 0) {
+			const placeholders = versionIds.map(() => '?').join(', ');
+			await connection.execute(`DELETE FROM Character_Version_Skills WHERE CharacterVersion IN (${placeholders})`, versionIds);
+			await connection.execute(`DELETE FROM Character_Version_Items WHERE CharacterVersion IN (${placeholders})`, versionIds);
+			await connection.execute(`DELETE FROM Character_Version_Implants WHERE CharacterVersion IN (${placeholders})`, versionIds);
+			await connection.execute(`DELETE FROM Event_Participants WHERE CharacterVersion IN (${placeholders})`, versionIds);
+		}
+
+		await connection.execute(`DELETE FROM Character_Versions WHERE Character = ?`, [id]);
+		await connection.execute(`DELETE FROM Party_Members WHERE Member = ?`, [id]);
+		await connection.execute(`DELETE FROM Characters WHERE Id = ?`, [id]);
 	}
 }
 

--- a/site/src/lib/db/character.repo.ts
+++ b/site/src/lib/db/character.repo.ts
@@ -114,7 +114,7 @@ class CharacterRepo {
 		const connection = mysqlconnFn();
 
 		const [versionRows] = await connection.execute(
-			`SELECT Id FROM Character_Versions WHERE Character = ?`,
+			`SELECT Id FROM Character_Versions WHERE \`Character\` = ?`,
 			[id]
 		);
 		const versionIds = (versionRows as any[]).map((r) => r.Id);
@@ -127,7 +127,7 @@ class CharacterRepo {
 			await connection.execute(`DELETE FROM Event_Participants WHERE CharacterVersion IN (${placeholders})`, versionIds);
 		}
 
-		await connection.execute(`DELETE FROM Character_Versions WHERE Character = ?`, [id]);
+		await connection.execute(`DELETE FROM Character_Versions WHERE \`Character\` = ?`, [id]);
 		await connection.execute(`DELETE FROM Party_Members WHERE Member = ?`, [id]);
 		await connection.execute(`DELETE FROM Characters WHERE Id = ?`, [id]);
 	}

--- a/site/src/routes/api/characters/[characterId]/+server.ts
+++ b/site/src/routes/api/characters/[characterId]/+server.ts
@@ -32,8 +32,9 @@ export const POST: RequestHandler = async ({ cookies, params, request }) => {
 export const DELETE: RequestHandler = async ({ cookies, params }) => {
   return handleRequest(async () => {
     await authGuardForUser(getSessionToken(cookies), ['admin']);
-    const id = isNumberOrError(params.characterId);
-    await characterRepo.delete({ id });
+    const { characterId } = params;
+    const numberId = isNumberOrError(characterId);
+    await characterRepo.delete(numberId);
     return new Response();
   });
 };


### PR DESCRIPTION
## Summary

- Adds `CharacterRepo.delete(id)` that fetches `Character_Version` IDs first, then deletes all child rows in the correct FK order — avoiding the `mysql2` `namedPlaceholders` subquery binding bug
- Adds the missing `DELETE /api/characters/[characterId]` route handler (admin-only)

## Deletion order

1. Fetch version IDs: `SELECT Id FROM Character_Versions WHERE Character = ?`
2. Delete child rows (only if versions exist): `Character_Version_Skills`, `Character_Version_Items`, `Character_Version_Implants`, `Event_Participants`
3. Delete `Character_Versions WHERE Character = ?`
4. Delete `Party_Members WHERE Member = ?`
5. Delete `Characters WHERE Id = ?`

## Test plan

- [ ] `curl -X DELETE /api/characters/:id` with a character that has versions, skills, items, implants, and event participation returns 200
- [ ] `curl -X DELETE /api/characters/:id` with a character that has no versions returns 200
- [ ] Verify no orphaned rows remain in any of the child tables after deletion
- [ ] Verify non-admin request returns 403

Closes #45

https://claude.ai/code/session_01NZo2NpQKbZGr6cmytjADft

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZo2NpQKbZGr6cmytjADft)_