### PR TITLE
TP-0048: Setup Vitest and add API handler tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,3 @@
-
 <CRITICAL_INSTRUCTION>
 
 ## TASK MANAGEMENT
@@ -34,3 +33,92 @@ This project uses **GitHub Issues** (via the `gh` CLI) for all task tracking. Th
 - Use `gh issue delete <N>` to remove a task
 
 </CRITICAL_INSTRUCTION>
+
+# Terra-Prime
+
+Full-stack SvelteKit + TypeScript web app for managing LARP events and characters. MySQL backend, real-time WebSocket support, and an Arduino/ESP32 companion device (`/cyd`).
+
+## Project structure
+
+```
+site/   - SvelteKit app (frontend + REST API)
+db/     - MySQL init scripts and migrations
+cyd/    - Arduino/ESP32 firmware (PlatformIO)
+```
+
+## Running the app
+
+```bash
+cd site
+pnpm dev          # dev server
+pnpm build        # production build
+pnpm start        # run production build
+```
+
+Docker Compose starts MySQL + PhpMyAdmin:
+```bash
+docker compose up
+```
+
+## Running tests
+
+```bash
+cd site
+pnpm test          # run once
+pnpm test:watch    # watch mode
+```
+
+Tests live in `site/src/tests/`. The test runner is **Vitest** (`site/vitest.config.ts`).
+
+## API
+
+All API routes are SvelteKit server files under `site/src/routes/api/`. They follow the pattern:
+
+```
+GET/POST/PUT/DELETE /api/<domain>/+server.ts
+```
+
+Key utilities:
+- `$lib/utils/request.ts` — `handleRequest`, `authGuard`, `authGuardForUser`
+- `$lib/utils/cookies.ts` — `getSessionToken`, `setSessionToken`
+- `$lib/types/errors.ts` — `BadRequest`, `NotFoundRequest`, `UnAutherizedRequestError`, `NoAccesRequest`
+- `$lib/db/*.repo.ts` — all database access (repository pattern, mysql2)
+
+## Testing rules
+
+**Whenever you add or modify an API route handler, you must also add or update the corresponding tests.**
+
+- Tests go in `site/src/tests/<domain>/`
+- Use `mockCookies(token?)` from `src/tests/helpers/mockCookies` to simulate auth
+- Use `mockRequest(body?)` from `src/tests/helpers/mockRequest` to build a request body
+- Use `createSessionRepoMock(session?)` from `src/tests/mocks/sessionRepo` and `vi.mock('$lib/db/session.repo', ...)` to stub auth
+- Every handler test must cover at minimum:
+  - Happy path (correct response body + status)
+  - Missing/invalid auth (expect rejection or error)
+  - Invalid request body where applicable (expect 400)
+
+Example test skeleton:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { mockCookies } from '../../tests/helpers/mockCookies';
+import { createSessionRepoMock } from '../../tests/mocks/sessionRepo';
+
+vi.mock('$lib/db/session.repo', () => ({ sessionRepo: createSessionRepoMock() }));
+vi.mock('$lib/db/skills.repo', () => ({ skillRepo: { getAll: vi.fn().mockResolvedValue([]) } }));
+
+import { GET } from '../../routes/api/skills/+server';
+
+describe('GET /api/skills', () => {
+  it('returns 200 with skills for an admin', async () => {
+    const res = await GET({ cookies: mockCookies('valid-token') } as any);
+    expect(res.status).toBe(200);
+  });
+});
+```
+
+## Auth roles
+
+`admin` | `player` | `extra` | `user`
+
+Most write endpoints require `admin`. Read endpoints vary — check the `authGuard` / `authGuardForUser` call in each handler.

--- a/site/package.json
+++ b/site/package.json
@@ -16,7 +16,9 @@
 		"start": "node ./build/index.js",
 		"start:websocket": "node ./websocket-server",
 		"migrate": "tsx db/migrate.ts",
-		"seed": "tsx db/seed.ts"
+		"seed": "tsx db/seed.ts",
+		"test": "vitest run",
+		"test:watch": "vitest"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^1.4.1",
@@ -37,7 +39,8 @@
 		"svelte-check": "^4.4.8",
 		"typescript": "^5.9.3",
 		"typescript-eslint": "^8.59.2",
-		"vite": "^6.4.2"
+		"vite": "^6.4.2",
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@google-cloud/local-auth": "^2.1.1",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       vite:
         specifier: ^6.4.2
         version: 6.4.2(@types/node@22.19.17)(tsx@4.21.0)
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@22.19.17)(vite@6.4.2(@types/node@22.19.17)(tsx@4.21.0))
 
 packages:
 
@@ -770,11 +773,17 @@ packages:
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -889,6 +898,35 @@ packages:
     resolution: {integrity: sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+
   '@webgpu/types@0.1.69':
     resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
 
@@ -920,6 +958,10 @@ packages:
   arrify@2.0.1:
     resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
     engines: {node: '>=8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   aws-ssl-profiles@1.1.2:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
@@ -975,6 +1017,10 @@ packages:
     peerDependencies:
       three: '>=0.126.1'
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -993,6 +1039,9 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -1069,6 +1118,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1171,6 +1223,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1178,6 +1233,10 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -1534,6 +1593,10 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -1574,6 +1637,9 @@ packages:
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1730,6 +1796,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -1742,9 +1811,15 @@ packages:
     resolution: {integrity: sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==}
     engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -1794,9 +1869,24 @@ packages:
   three@0.180.0:
     resolution: {integrity: sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -1933,6 +2023,47 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   webgl-sdf-generator@1.1.1:
     resolution: {integrity: sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==}
 
@@ -1945,6 +2076,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2443,11 +2579,18 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/node': 22.19.17
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 22.19.17
 
   '@types/cookie@0.6.0': {}
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -2601,6 +2744,47 @@ snapshots:
       '@typescript-eslint/types': 8.59.2
       eslint-visitor-keys: 5.0.1
 
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@6.4.2(@types/node@22.19.17)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.2(@types/node@22.19.17)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@webgpu/types@0.1.69': {}
 
   accepts@2.0.0:
@@ -2630,6 +2814,8 @@ snapshots:
   aria-query@5.3.1: {}
 
   arrify@2.0.1: {}
+
+  assertion-error@2.0.1: {}
 
   aws-ssl-profiles@1.1.2: {}
 
@@ -2686,6 +2872,8 @@ snapshots:
     dependencies:
       three: 0.180.0
 
+  chai@6.2.2: {}
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -2697,6 +2885,8 @@ snapshots:
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie-signature@1.2.2: {}
 
@@ -2747,6 +2937,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -2921,9 +3113,15 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
+
+  expect-type@1.3.0: {}
 
   express@5.2.1:
     dependencies:
@@ -3298,6 +3496,8 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
+  obug@2.1.3: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -3337,6 +3537,8 @@ snapshots:
   path-parse@1.0.7: {}
 
   path-to-regexp@8.4.2: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -3526,6 +3728,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -3536,7 +3740,11 @@ snapshots:
 
   sql-escaper@1.3.3: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@4.1.0: {}
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
@@ -3606,10 +3814,21 @@ snapshots:
 
   three@0.180.0: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   toidentifier@1.0.1: {}
 
@@ -3702,6 +3921,33 @@ snapshots:
     optionalDependencies:
       vite: 6.4.2(@types/node@22.19.17)(tsx@4.21.0)
 
+  vitest@4.1.8(@types/node@22.19.17)(vite@6.4.2(@types/node@22.19.17)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@6.4.2(@types/node@22.19.17)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 6.4.2(@types/node@22.19.17)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - msw
+
   webgl-sdf-generator@1.1.1: {}
 
   webidl-conversions@3.0.1: {}
@@ -3714,6 +3960,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/site/src/tests/authentication/login.test.ts
+++ b/site/src/tests/authentication/login.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mockCookies } from '../helpers/mockCookies';
+import { mockRequest } from '../helpers/mockRequest';
+import { createSessionRepoMock } from '../mocks/sessionRepo';
+import { createAuthRepoMock } from '../mocks/authenticationRepo';
+
+vi.mock('$lib/db/session.repo', () => ({ sessionRepo: createSessionRepoMock() }));
+vi.mock('$lib/db/authentication.repo', () => ({ authenticationRepo: createAuthRepoMock() }));
+
+import { POST } from '../../routes/api/authentication/login/+server';
+import { authenticationRepo } from '$lib/db/authentication.repo';
+
+describe('POST /api/authentication/login', () => {
+	it('returns 200 with token, roles, name, userId on valid credentials', async () => {
+		const res = await POST({
+			request: mockRequest({ email: 'test@test.com', password: 'password' }),
+			cookies: mockCookies(),
+		} as any);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body).toHaveProperty('token');
+		expect(body).toHaveProperty('roles');
+	});
+
+	it('rejects when credentials are not found', async () => {
+		vi.mocked(authenticationRepo.getCredentials).mockResolvedValueOnce(null);
+		await expect(
+			POST({
+				request: mockRequest({ email: 'bad@test.com', password: 'wrong' }),
+				cookies: mockCookies(),
+			} as any)
+		).rejects.toThrow();
+	});
+
+	it('rejects when email and password are missing', async () => {
+		await expect(
+			POST({
+				request: mockRequest({}),
+				cookies: mockCookies(),
+			} as any)
+		).rejects.toThrow();
+	});
+});

--- a/site/src/tests/authentication/register.test.ts
+++ b/site/src/tests/authentication/register.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mockCookies } from '../helpers/mockCookies';
+import { mockRequest } from '../helpers/mockRequest';
+import { createSessionRepoMock } from '../mocks/sessionRepo';
+import { createAuthRepoMock } from '../mocks/authenticationRepo';
+
+vi.mock('$lib/db/session.repo', () => ({ sessionRepo: createSessionRepoMock() }));
+vi.mock('$lib/db/authentication.repo', () => ({ authenticationRepo: createAuthRepoMock() }));
+vi.mock('$lib/server/verification.service', () => ({ sendVerificationEmail: vi.fn().mockResolvedValue(undefined) }));
+
+import { POST } from '../../routes/api/authentication/register/+server';
+
+const validBody = { name: 'Alice', email: 'alice@test.com', password: 'password123' };
+
+describe('POST /api/authentication/register', () => {
+	it('returns 200 with userId and roles when registration is enabled', async () => {
+		const res = await POST({
+			request: mockRequest(validBody),
+			cookies: mockCookies(),
+			locals: { featureFlags: { Register: true } },
+		} as any);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body).toHaveProperty('userId');
+		expect(body).toHaveProperty('roles');
+	});
+
+	it('rejects with 403 when registration is disabled', async () => {
+		await expect(
+			POST({
+				request: mockRequest(validBody),
+				cookies: mockCookies(),
+				locals: { featureFlags: { Register: false } },
+			} as any)
+		).rejects.toThrow();
+	});
+
+	it('rejects when required fields are missing', async () => {
+		await expect(
+			POST({
+				request: mockRequest({}),
+				cookies: mockCookies(),
+				locals: { featureFlags: { Register: true } },
+			} as any)
+		).rejects.toThrow();
+	});
+});

--- a/site/src/tests/authentication/token.test.ts
+++ b/site/src/tests/authentication/token.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mockCookies } from '../helpers/mockCookies';
+import { mockRequest } from '../helpers/mockRequest';
+import { createSessionRepoMock } from '../mocks/sessionRepo';
+
+vi.mock('$lib/db/session.repo', () => ({ sessionRepo: createSessionRepoMock() }));
+
+import { POST } from '../../routes/api/authentication/login/token/+server';
+
+describe('POST /api/authentication/login/token', () => {
+	it('returns 200 with the token when a valid token string is provided', async () => {
+		const res = await POST({
+			request: mockRequest({ token: 'my-existing-token' }),
+			cookies: mockCookies(),
+		} as any);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body).toHaveProperty('token', 'my-existing-token');
+	});
+
+	it('rejects when token is missing from the body', async () => {
+		await expect(
+			POST({
+				request: mockRequest({}),
+				cookies: mockCookies(),
+			} as any)
+		).rejects.toThrow();
+	});
+});

--- a/site/src/tests/characters/handlers.test.ts
+++ b/site/src/tests/characters/handlers.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mockCookies } from '../helpers/mockCookies';
+import { mockRequest } from '../helpers/mockRequest';
+import { createSessionRepoMock, playerSession } from '../mocks/sessionRepo';
+
+const { mockCharacter, mockVersion } = vi.hoisted(() => ({
+	mockCharacter: { id: 1, name: 'Aria', ownerId: 1, ownerName: 'Player One', backstoryUrl: null },
+	mockVersion: { id: 1, characterId: 1, name: 'Version 1', company: 1, skills: [], items: [], implants: [] },
+}));
+
+const mockNewCharacter = { name: 'Aria', ownerId: 1 };
+
+vi.mock('$lib/db/session.repo', () => ({ sessionRepo: createSessionRepoMock() }));
+vi.mock('$lib/db/character.repo', async () => ({
+	characterRepo: {
+		getAll: vi.fn().mockResolvedValue([mockCharacter]),
+		getById: vi.fn().mockResolvedValue(mockCharacter),
+		save: vi.fn().mockResolvedValue(1),
+		getForUser: vi.fn().mockResolvedValue([mockCharacter]),
+		getByOwner: vi.fn().mockResolvedValue([mockCharacter]),
+	},
+	isCharacter: (await import('$lib/db/character.repo')).isCharacter,
+	isNewCharacter: (await import('$lib/db/character.repo')).isNewCharacter,
+}));
+vi.mock('$lib/db/character_version.repo', async () => ({
+	characterVersionRepo: {
+		getAllWithCharacterName: vi.fn().mockResolvedValue([]),
+		getWithId: vi.fn().mockResolvedValue(mockVersion),
+		getForCharacter: vi.fn().mockResolvedValue([mockVersion]),
+		save: vi.fn().mockResolvedValue(1),
+		create: vi.fn().mockResolvedValue(1),
+		saveSkills: vi.fn().mockResolvedValue(undefined),
+		getForUser: vi.fn().mockResolvedValue([mockVersion]),
+	},
+	isCharacterVersionBare: (await import('$lib/db/character_version.repo')).isCharacterVersionBare,
+	isCharacterVersionSkill: (await import('$lib/db/character_version.repo')).isCharacterVersionSkill,
+}));
+vi.mock('$lib/db/skills.repo', () => ({ skillRepo: { getAll: vi.fn().mockResolvedValue([]) } }));
+vi.mock('$lib/db/items.repo', () => ({ itemRepo: { getAll: vi.fn().mockResolvedValue([]) } }));
+vi.mock('$lib/db/implants.repo', () => ({ implantRepo: { getAll: vi.fn().mockResolvedValue([]) } }));
+vi.mock('$lib/db/companies.repo', () => ({ companyRepo: { getAll: vi.fn().mockResolvedValue([{ id: 1, name: 'Test Corp' }]) } }));
+vi.mock('$lib/db/event_participants.repo', () => ({
+	eventParticipantsRepo: {
+		getParticipantForCharacter: vi.fn().mockResolvedValue({ eventId: 1, userId: 1, characterVersion: 1 }),
+	},
+}));
+
+import { GET as getCharacters, PUT as putCharacter } from '../../routes/api/characters/+server';
+import { GET as getCharacterById, POST as postCharacterById } from '../../routes/api/characters/[characterId]/+server';
+import { GET as getVersions, PUT as putVersion } from '../../routes/api/characters/versions/+server';
+import { GET as getVersionById, PUT as putVersionById } from '../../routes/api/characters/versions/[versionId]/+server';
+import { PUT as putVersionSkills } from '../../routes/api/characters/versions/[versionId]/skills/+server';
+import { GET as getCharacterVersions, PUT as putCharacterVersion } from '../../routes/api/characters/[characterId]/versions/+server';
+import { sessionRepo } from '$lib/db/session.repo';
+
+describe('GET /api/characters', () => {
+	it('returns 200 with characters list for admin', async () => {
+		const res = await getCharacters({ cookies: mockCookies('token') } as any);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(Array.isArray(body)).toBe(true);
+	});
+
+	it('rejects without auth', async () => {
+		await expect(getCharacters({ cookies: mockCookies() } as any)).rejects.toThrow();
+	});
+});
+
+describe('PUT /api/characters', () => {
+	it('returns 200 with id when creating a valid character', async () => {
+		const res = await putCharacter({
+			cookies: mockCookies('token'),
+			request: mockRequest(mockNewCharacter),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		await expect(
+			putCharacter({ cookies: mockCookies('token'), request: mockRequest({}) } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('GET /api/characters/[characterId]', () => {
+	it('returns 200 with character when found', async () => {
+		const res = await getCharacterById({
+			cookies: mockCookies('token'),
+			params: { characterId: '1' },
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects without auth', async () => {
+		await expect(
+			getCharacterById({ cookies: mockCookies(), params: { characterId: '1' } } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('POST /api/characters/[characterId]', () => {
+	it('returns 200 for a valid character update', async () => {
+		const res = await postCharacterById({
+			cookies: mockCookies('token'),
+			params: { id: '1', characterId: '1' },
+			request: mockRequest(mockCharacter),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		await expect(
+			postCharacterById({
+				cookies: mockCookies('token'),
+				params: { id: '1', characterId: '1' },
+				request: mockRequest({}),
+			} as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('GET /api/characters/versions', () => {
+	it('returns 200 with versions list for admin', async () => {
+		const res = await getVersions({ cookies: mockCookies('token') } as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects without auth', async () => {
+		await expect(getVersions({ cookies: mockCookies() } as any)).rejects.toThrow();
+	});
+});
+
+describe('PUT /api/characters/versions', () => {
+	it('returns 200 with id when creating a valid version', async () => {
+		vi.mocked(sessionRepo.getCredentials).mockResolvedValueOnce(playerSession);
+		const res = await putVersion({
+			cookies: mockCookies('token'),
+			request: mockRequest(mockVersion),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		vi.mocked(sessionRepo.getCredentials).mockResolvedValueOnce(playerSession);
+		await expect(
+			putVersion({ cookies: mockCookies('token'), request: mockRequest({}) } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('GET /api/characters/versions/[versionId]', () => {
+	it('returns 200 when version found', async () => {
+		const res = await getVersionById({
+			cookies: mockCookies('token'),
+			params: { versionId: '1' },
+		} as any);
+		expect(res.status).toBe(200);
+	});
+});
+
+describe('PUT /api/characters/versions/[versionId]', () => {
+	it('returns 200 for valid version update', async () => {
+		vi.mocked(sessionRepo.getCredentials).mockResolvedValueOnce(playerSession);
+		const res = await putVersionById({
+			cookies: mockCookies('token'),
+			params: { versionId: '1' },
+			request: mockRequest(mockVersion),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+});
+
+describe('PUT /api/characters/versions/[versionId]/skills', () => {
+	it('returns 200 for a valid skills array', async () => {
+		vi.mocked(sessionRepo.getCredentials).mockResolvedValueOnce(playerSession);
+		const res = await putVersionSkills({
+			cookies: mockCookies('token'),
+			params: { versionId: '1' },
+			request: mockRequest([{ id: 1, value: 5 }]),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body (not an array)', async () => {
+		vi.mocked(sessionRepo.getCredentials).mockResolvedValueOnce(playerSession);
+		await expect(
+			putVersionSkills({
+				cookies: mockCookies('token'),
+				params: { versionId: '1' },
+				request: mockRequest({ id: 1 }),
+			} as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('GET /api/characters/[characterId]/versions', () => {
+	it('returns 200 with versions for the character', async () => {
+		const res = await getCharacterVersions({
+			cookies: mockCookies('token'),
+			params: { characterId: '1' },
+		} as any);
+		expect(res.status).toBe(200);
+	});
+});
+
+describe('PUT /api/characters/[characterId]/versions', () => {
+	it('returns 200 when creating a version for a character', async () => {
+		const res = await putCharacterVersion({
+			cookies: mockCookies('token'),
+			params: { characterId: '1' },
+		} as any);
+		expect(res.status).toBe(200);
+	});
+});

--- a/site/src/tests/companies/handlers.test.ts
+++ b/site/src/tests/companies/handlers.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mockCookies } from '../helpers/mockCookies';
+import { mockRequest } from '../helpers/mockRequest';
+import { createSessionRepoMock } from '../mocks/sessionRepo';
+
+const { mockCompany, mockDiscounts } = vi.hoisted(() => ({
+	mockCompany: { id: 1, name: 'Acme Corp', description: 'A corp', link: null },
+	mockDiscounts: { items: [], implants: [], skills: [] },
+}));
+
+vi.mock('$lib/db/session.repo', () => ({ sessionRepo: createSessionRepoMock() }));
+vi.mock('$lib/db/companies.repo', async () => ({
+	companyRepo: {
+		getAll: vi.fn().mockResolvedValue([mockCompany]),
+		getWithId: vi.fn().mockResolvedValue(mockCompany),
+		save: vi.fn().mockResolvedValue(1),
+		delete: vi.fn().mockResolvedValue(undefined),
+	},
+	isCompany: (await import('$lib/db/companies.repo')).isCompany,
+}));
+vi.mock('$lib/db/company_discounts.repo', async () => ({
+	companyDiscountsRepo: {
+		getByCompany: vi.fn().mockResolvedValue(mockDiscounts),
+		setDiscounts: vi.fn().mockResolvedValue(undefined),
+	},
+	isCompanyDiscounts: (await import('$lib/db/company_discounts.repo')).isCompanyDiscounts,
+}));
+
+import { GET as getCompanies, PUT as putCompany } from '../../routes/api/companies/+server';
+import { GET as getCompanyById, POST as postCompanyById, DELETE as deleteCompanyById } from '../../routes/api/companies/[id]/+server';
+import { GET as getDiscounts, POST as postDiscounts } from '../../routes/api/companies/[id]/discounts/+server';
+import { sessionRepo } from '$lib/db/session.repo';
+import { companyRepo } from '$lib/db/companies.repo';
+
+describe('GET /api/companies', () => {
+	it('returns 200 with companies list', async () => {
+		const res = await getCompanies({ cookies: mockCookies('token') } as any);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(Array.isArray(body)).toBe(true);
+	});
+
+	it('rejects without auth', async () => {
+		await expect(getCompanies({ cookies: mockCookies() } as any)).rejects.toThrow();
+	});
+});
+
+describe('PUT /api/companies', () => {
+	it('returns 200 for a valid company body', async () => {
+		const res = await putCompany({
+			cookies: mockCookies('token'),
+			request: mockRequest(mockCompany),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		await expect(
+			putCompany({ cookies: mockCookies('token'), request: mockRequest({}) } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('GET /api/companies/[id]', () => {
+	it('returns 200 with company when found', async () => {
+		const res = await getCompanyById({ cookies: mockCookies('token'), params: { id: '1' } } as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects when company not found', async () => {
+		vi.mocked(companyRepo.getWithId).mockResolvedValueOnce(null);
+		await expect(
+			getCompanyById({ cookies: mockCookies('token'), params: { id: '999' } } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('POST /api/companies/[id]', () => {
+	it('returns 200 for a valid update', async () => {
+		const res = await postCompanyById({
+			cookies: mockCookies('token'),
+			params: { id: '1' },
+			request: mockRequest(mockCompany),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		await expect(
+			postCompanyById({
+				cookies: mockCookies('token'),
+				params: { id: '1' },
+				request: mockRequest({}),
+			} as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('DELETE /api/companies/[id]', () => {
+	it('returns 200 on successful delete', async () => {
+		const res = await deleteCompanyById({ cookies: mockCookies('token'), params: { id: '1' } } as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects without auth', async () => {
+		await expect(
+			deleteCompanyById({ cookies: mockCookies(), params: { id: '1' } } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('GET /api/companies/[id]/discounts', () => {
+	it('returns 200 with discounts', async () => {
+		const res = await getDiscounts({ cookies: mockCookies('token'), params: { id: '1' } } as any);
+		expect(res.status).toBe(200);
+	});
+});
+
+describe('POST /api/companies/[id]/discounts', () => {
+	it('returns 200 for valid discounts body', async () => {
+		const res = await postDiscounts({
+			cookies: mockCookies('token'),
+			params: { id: '1' },
+			request: mockRequest(mockDiscounts),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		await expect(
+			postDiscounts({
+				cookies: mockCookies('token'),
+				params: { id: '1' },
+				request: mockRequest({ wrong: true }),
+			} as any)
+		).rejects.toThrow();
+	});
+});

--- a/site/src/tests/email-templates/handlers.test.ts
+++ b/site/src/tests/email-templates/handlers.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mockCookies } from '../helpers/mockCookies';
+import { mockRequest } from '../helpers/mockRequest';
+import { createSessionRepoMock } from '../mocks/sessionRepo';
+
+const { mockTemplate } = vi.hoisted(() => ({
+	mockTemplate: { id: 1, key: 'welcome', docUrl: 'https://docs.google.com/document/d/abc/edit' },
+}));
+
+vi.mock('$lib/db/session.repo', () => ({ sessionRepo: createSessionRepoMock() }));
+vi.mock('$lib/db/email_template.repo', async () => ({
+	emailTemplateRepo: {
+		getAll: vi.fn().mockResolvedValue([mockTemplate]),
+		getById: vi.fn().mockResolvedValue(mockTemplate),
+		save: vi.fn().mockResolvedValue(1),
+		delete: vi.fn().mockResolvedValue(undefined),
+	},
+	isEmailTemplate: (await import('$lib/db/email_template.repo')).isEmailTemplate,
+}));
+
+import { GET as getTemplates, PUT as putTemplate } from '../../routes/api/email-templates/+server';
+import { GET as getTemplateById, POST as postTemplateById, DELETE as deleteTemplateById } from '../../routes/api/email-templates/[id]/+server';
+import { sessionRepo } from '$lib/db/session.repo';
+import { emailTemplateRepo } from '$lib/db/email_template.repo';
+
+describe('GET /api/email-templates', () => {
+	it('returns 200 with templates list for admin', async () => {
+		const res = await getTemplates({ cookies: mockCookies('token') } as any);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(Array.isArray(body)).toBe(true);
+	});
+
+	it('rejects without auth', async () => {
+		await expect(getTemplates({ cookies: mockCookies() } as any)).rejects.toThrow();
+	});
+
+	it('rejects with invalid session', async () => {
+		vi.mocked(sessionRepo.getCredentials).mockResolvedValueOnce(null);
+		await expect(getTemplates({ cookies: mockCookies('bad') } as any)).rejects.toThrow();
+	});
+});
+
+describe('PUT /api/email-templates', () => {
+	it('returns 200 for a valid template body', async () => {
+		const res = await putTemplate({
+			cookies: mockCookies('token'),
+			request: mockRequest(mockTemplate),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		await expect(
+			putTemplate({ cookies: mockCookies('token'), request: mockRequest({}) } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('GET /api/email-templates/[id]', () => {
+	it('returns 200 with template when found', async () => {
+		const res = await getTemplateById({ cookies: mockCookies('token'), params: { id: '1' } } as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects when template not found', async () => {
+		vi.mocked(emailTemplateRepo.getById).mockResolvedValueOnce(null);
+		await expect(
+			getTemplateById({ cookies: mockCookies('token'), params: { id: '999' } } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('POST /api/email-templates/[id]', () => {
+	it('returns 200 for a valid update', async () => {
+		const res = await postTemplateById({
+			cookies: mockCookies('token'),
+			params: { id: '1' },
+			request: mockRequest(mockTemplate),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		await expect(
+			postTemplateById({
+				cookies: mockCookies('token'),
+				params: { id: '1' },
+				request: mockRequest({}),
+			} as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('DELETE /api/email-templates/[id]', () => {
+	it('returns 200 on successful delete', async () => {
+		const res = await deleteTemplateById({ cookies: mockCookies('token'), params: { id: '1' } } as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects without auth', async () => {
+		await expect(
+			deleteTemplateById({ cookies: mockCookies(), params: { id: '1' } } as any)
+		).rejects.toThrow();
+	});
+});

--- a/site/src/tests/events/handlers.test.ts
+++ b/site/src/tests/events/handlers.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mockCookies } from '../helpers/mockCookies';
+import { mockRequest } from '../helpers/mockRequest';
+import { createSessionRepoMock, playerSession } from '../mocks/sessionRepo';
+
+const { mockEvent, mockParticipant, mockCharacter, mockVersion } = vi.hoisted(() => ({
+	mockEvent: {
+		id: 1,
+		name: 'Summer LARP',
+		start: new Date('2026-07-01'),
+		end: new Date('2026-07-03'),
+		status: 'Open' as const,
+	},
+	mockParticipant: { eventId: 1, userId: 1, characterVersion: 1 },
+	mockCharacter: { id: 1, name: 'Aria', ownerId: 1, ownerName: 'Player One', backstoryUrl: null },
+	mockVersion: { id: 1, characterId: 1, name: 'V1', company: 1, skills: [], items: [], implants: [] },
+}));
+
+vi.mock('$lib/db/session.repo', () => ({ sessionRepo: createSessionRepoMock() }));
+vi.mock('$lib/db/event.repo', async () => ({
+	eventRepo: {
+		getAll: vi.fn().mockResolvedValue([mockEvent]),
+		getWithId: vi.fn().mockResolvedValue(mockEvent),
+		getWithStatus: vi.fn().mockResolvedValue([mockEvent]),
+		save: vi.fn().mockResolvedValue(1),
+		delete: vi.fn().mockResolvedValue(undefined),
+	},
+	isLarpEvent: (await import('$lib/db/event.repo')).isLarpEvent,
+	isStringLarpEvent: (await import('$lib/db/event.repo')).isStringLarpEvent,
+}));
+vi.mock('$lib/db/event_participants.repo', async () => ({
+	eventParticipantsRepo: {
+		getPerticipants: vi.fn().mockResolvedValue([mockCharacter]),
+		getUserParticipation: vi.fn().mockResolvedValue(undefined),
+		participate: vi.fn().mockResolvedValue(undefined),
+		withdraw: vi.fn().mockResolvedValue(undefined),
+		getParticipantForCharacter: vi.fn().mockResolvedValue(mockParticipant),
+	},
+	isEventParticapant: (await import('$lib/db/event_participants.repo')).isEventParticapant,
+}));
+vi.mock('$lib/db/character.repo', async () => ({
+	characterRepo: { save: vi.fn().mockResolvedValue(1) },
+	isCharacter: (await import('$lib/db/character.repo')).isCharacter,
+	isNewCharacter: (await import('$lib/db/character.repo')).isNewCharacter,
+}));
+vi.mock('$lib/db/character_version.repo', async () => ({
+	characterVersionRepo: { save: vi.fn().mockResolvedValue(1) },
+	isCharacterVersionBare: (await import('$lib/db/character_version.repo')).isCharacterVersionBare,
+}));
+
+import { GET as getEvents } from '../../routes/api/events/+server';
+import { GET as getOpenEvents } from '../../routes/api/events/open/+server';
+import { GET as getEventById, DELETE as deleteEvent } from '../../routes/api/events/[eventId]/+server';
+import { GET as getParticipants, PUT as putParticipant, DELETE as deleteParticipant } from '../../routes/api/events/[eventId]/participants/+server';
+import { GET as getParticipantForCharacter } from '../../routes/api/events/[eventId]/participants/characters/[characterId]/+server';
+import { sessionRepo } from '$lib/db/session.repo';
+import { eventRepo } from '$lib/db/event.repo';
+
+describe('GET /api/events', () => {
+	it('returns 200 with events list for admin', async () => {
+		const res = await getEvents({ cookies: mockCookies('token') } as any);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(Array.isArray(body)).toBe(true);
+	});
+
+	it('rejects without auth', async () => {
+		await expect(getEvents({ cookies: mockCookies() } as any)).rejects.toThrow();
+	});
+
+	it('rejects with invalid session', async () => {
+		vi.mocked(sessionRepo.getCredentials).mockResolvedValueOnce(null);
+		await expect(getEvents({ cookies: mockCookies('bad') } as any)).rejects.toThrow();
+	});
+});
+
+describe('GET /api/events/open', () => {
+	it('returns 200 with open events', async () => {
+		const res = await getOpenEvents({ cookies: mockCookies('token') } as any);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(Array.isArray(body)).toBe(true);
+	});
+});
+
+describe('GET /api/events/[eventId]', () => {
+	it('returns 200 with event when found', async () => {
+		const res = await getEventById({ cookies: mockCookies('token'), params: { eventId: '1' } } as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects when event not found', async () => {
+		vi.mocked(eventRepo.getWithId).mockResolvedValueOnce(undefined);
+		await expect(
+			getEventById({ cookies: mockCookies('token'), params: { eventId: '999' } } as any)
+		).rejects.toThrow();
+	});
+
+	it('rejects without auth', async () => {
+		await expect(
+			getEventById({ cookies: mockCookies(), params: { eventId: '1' } } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('DELETE /api/events/[eventId]', () => {
+	it('returns 200 on successful delete', async () => {
+		const res = await deleteEvent({ cookies: mockCookies('token'), params: { eventId: '1' } } as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects without auth', async () => {
+		await expect(
+			deleteEvent({ cookies: mockCookies(), params: { eventId: '1' } } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('GET /api/events/[eventId]/participants', () => {
+	it('returns 200 with participants list', async () => {
+		const res = await getParticipants({ cookies: mockCookies('token'), params: { eventId: '1' } } as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects without auth', async () => {
+		await expect(
+			getParticipants({ cookies: mockCookies(), params: { eventId: '1' } } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('PUT /api/events/[eventId]/participants', () => {
+	const validBody = {
+		id: null,
+		name: 'Aria',
+		ownerId: 1,
+		ownerName: 'Player One',
+		versions: [mockVersion],
+	};
+
+	it('returns 200 for valid participant body', async () => {
+		const res = await putParticipant({
+			cookies: mockCookies('token'),
+			params: { eventId: '1' },
+			request: mockRequest(validBody),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		await expect(
+			putParticipant({
+				cookies: mockCookies('token'),
+				params: { eventId: '1' },
+				request: mockRequest({}),
+			} as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('DELETE /api/events/[eventId]/participants', () => {
+	it('returns 200 for valid participant removal', async () => {
+		const res = await deleteParticipant({
+			cookies: mockCookies('token'),
+			request: mockRequest(mockParticipant),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		await expect(
+			deleteParticipant({
+				cookies: mockCookies('token'),
+				request: mockRequest({}),
+			} as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('GET /api/events/[eventId]/participants/characters/[characterId]', () => {
+	it('returns 200 with participant record', async () => {
+		vi.mocked(sessionRepo.getCredentials).mockResolvedValueOnce(playerSession);
+		const res = await getParticipantForCharacter({
+			cookies: mockCookies('token'),
+			params: { eventId: '1', characterId: '1' },
+		} as any);
+		expect(res.status).toBe(200);
+	});
+});

--- a/site/src/tests/helpers/mockCookies.ts
+++ b/site/src/tests/helpers/mockCookies.ts
@@ -1,0 +1,18 @@
+import type { Cookies } from '@sveltejs/kit';
+
+export function mockCookies(token?: string): Cookies {
+	const store = new Map<string, string>();
+	if (token) store.set('session-token', token);
+
+	return {
+		get: (name: string) => store.get(name),
+		getAll: () => [...store.entries()].map(([name, value]) => ({ name, value })),
+		set: (name: string, value: string) => {
+			store.set(name, value);
+		},
+		delete: (name: string) => {
+			store.delete(name);
+		},
+		serialize: () => '',
+	} as unknown as Cookies;
+}

--- a/site/src/tests/helpers/mockRequest.ts
+++ b/site/src/tests/helpers/mockRequest.ts
@@ -1,0 +1,7 @@
+export function mockRequest(body?: unknown, method = 'POST'): Request {
+	return new Request('http://localhost', {
+		method,
+		headers: { 'Content-Type': 'application/json' },
+		body: body != null ? JSON.stringify(body) : undefined,
+	});
+}

--- a/site/src/tests/implants/handlers.test.ts
+++ b/site/src/tests/implants/handlers.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mockCookies } from '../helpers/mockCookies';
+import { mockRequest } from '../helpers/mockRequest';
+import { createSessionRepoMock } from '../mocks/sessionRepo';
+
+const { mockImplant } = vi.hoisted(() => ({
+	mockImplant: { id: 1, name: 'Neural Chip', description: 'A neural implant' },
+}));
+
+vi.mock('$lib/db/session.repo', () => ({ sessionRepo: createSessionRepoMock() }));
+vi.mock('$lib/db/implants.repo', async () => ({
+	implantRepo: {
+		getAll: vi.fn().mockResolvedValue([mockImplant]),
+		getWithId: vi.fn().mockResolvedValue(mockImplant),
+		save: vi.fn().mockResolvedValue(1),
+		delete: vi.fn().mockResolvedValue(undefined),
+	},
+	isImplants: (await import('$lib/db/implants.repo')).isImplants,
+}));
+
+import { GET as getImplants, PUT as putImplant } from '../../routes/api/implants/+server';
+import { GET as getImplantById, POST as postImplantById, DELETE as deleteImplantById } from '../../routes/api/implants/[id]/+server';
+import { sessionRepo } from '$lib/db/session.repo';
+import { implantRepo } from '$lib/db/implants.repo';
+
+describe('GET /api/implants', () => {
+	it('returns 200 with implants list', async () => {
+		const res = await getImplants({ cookies: mockCookies('token') } as any);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(Array.isArray(body)).toBe(true);
+	});
+
+	it('rejects without auth token', async () => {
+		await expect(getImplants({ cookies: mockCookies() } as any)).rejects.toThrow();
+	});
+
+	it('rejects with invalid session', async () => {
+		vi.mocked(sessionRepo.getCredentials).mockResolvedValueOnce(null);
+		await expect(getImplants({ cookies: mockCookies('bad') } as any)).rejects.toThrow();
+	});
+});
+
+describe('PUT /api/implants', () => {
+	it('returns 200 for a valid implant body', async () => {
+		const res = await putImplant({
+			cookies: mockCookies('token'),
+			request: mockRequest(mockImplant),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		await expect(
+			putImplant({ cookies: mockCookies('token'), request: mockRequest({}) } as any)
+		).rejects.toThrow();
+	});
+
+	it('rejects without auth', async () => {
+		await expect(
+			putImplant({ cookies: mockCookies(), request: mockRequest(mockImplant) } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('GET /api/implants/[id]', () => {
+	it('returns 200 with implant when found', async () => {
+		const res = await getImplantById({ cookies: mockCookies('token'), params: { id: '1' } } as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects when implant not found', async () => {
+		vi.mocked(implantRepo.getWithId).mockResolvedValueOnce(null);
+		await expect(
+			getImplantById({ cookies: mockCookies('token'), params: { id: '999' } } as any)
+		).rejects.toThrow();
+	});
+
+	it('rejects without auth', async () => {
+		await expect(
+			getImplantById({ cookies: mockCookies(), params: { id: '1' } } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('POST /api/implants/[id]', () => {
+	it('returns 200 for a valid implant update', async () => {
+		const res = await postImplantById({
+			cookies: mockCookies('token'),
+			params: { id: '1' },
+			request: mockRequest(mockImplant),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		await expect(
+			postImplantById({
+				cookies: mockCookies('token'),
+				params: { id: '1' },
+				request: mockRequest({}),
+			} as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('DELETE /api/implants/[id]', () => {
+	it('returns 200 on successful delete', async () => {
+		const res = await deleteImplantById({ cookies: mockCookies('token'), params: { id: '1' } } as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects without auth', async () => {
+		await expect(
+			deleteImplantById({ cookies: mockCookies(), params: { id: '1' } } as any)
+		).rejects.toThrow();
+	});
+});

--- a/site/src/tests/items/handlers.test.ts
+++ b/site/src/tests/items/handlers.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mockCookies } from '../helpers/mockCookies';
+import { mockRequest } from '../helpers/mockRequest';
+import { createSessionRepoMock } from '../mocks/sessionRepo';
+
+const { mockItem } = vi.hoisted(() => ({
+	mockItem: { id: 1, name: 'Sword', description: 'A sharp sword' },
+}));
+
+vi.mock('$lib/db/session.repo', () => ({ sessionRepo: createSessionRepoMock() }));
+vi.mock('$lib/db/items.repo', async () => ({
+	itemRepo: {
+		getAll: vi.fn().mockResolvedValue([mockItem]),
+		getWithId: vi.fn().mockResolvedValue(mockItem),
+		save: vi.fn().mockResolvedValue(1),
+		delete: vi.fn().mockResolvedValue(undefined),
+	},
+	isItem: (await import('$lib/db/items.repo')).isItem,
+}));
+
+import { GET as getItems, PUT as putItem } from '../../routes/api/items/+server';
+import { GET as getItemById, POST as postItemById, DELETE as deleteItemById } from '../../routes/api/items/[id]/+server';
+import { sessionRepo } from '$lib/db/session.repo';
+import { itemRepo } from '$lib/db/items.repo';
+
+describe('GET /api/items', () => {
+	it('returns 200 with items list', async () => {
+		const res = await getItems({ cookies: mockCookies('token') } as any);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(Array.isArray(body)).toBe(true);
+	});
+
+	it('rejects without auth token', async () => {
+		await expect(getItems({ cookies: mockCookies() } as any)).rejects.toThrow();
+	});
+
+	it('rejects with invalid session', async () => {
+		vi.mocked(sessionRepo.getCredentials).mockResolvedValueOnce(null);
+		await expect(getItems({ cookies: mockCookies('bad') } as any)).rejects.toThrow();
+	});
+});
+
+describe('PUT /api/items', () => {
+	it('returns 200 for a valid item body', async () => {
+		const res = await putItem({
+			cookies: mockCookies('token'),
+			request: mockRequest(mockItem),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		await expect(
+			putItem({ cookies: mockCookies('token'), request: mockRequest({}) } as any)
+		).rejects.toThrow();
+	});
+
+	it('rejects without auth', async () => {
+		await expect(
+			putItem({ cookies: mockCookies(), request: mockRequest(mockItem) } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('GET /api/items/[id]', () => {
+	it('returns 200 with item when found', async () => {
+		const res = await getItemById({ cookies: mockCookies('token'), params: { id: '1' } } as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects when item not found', async () => {
+		vi.mocked(itemRepo.getWithId).mockResolvedValueOnce(null);
+		await expect(
+			getItemById({ cookies: mockCookies('token'), params: { id: '999' } } as any)
+		).rejects.toThrow();
+	});
+
+	it('rejects without auth', async () => {
+		await expect(getItemById({ cookies: mockCookies(), params: { id: '1' } } as any)).rejects.toThrow();
+	});
+});
+
+describe('POST /api/items/[id]', () => {
+	it('returns 200 for a valid item update', async () => {
+		const res = await postItemById({
+			cookies: mockCookies('token'),
+			params: { id: '1' },
+			request: mockRequest(mockItem),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		await expect(
+			postItemById({
+				cookies: mockCookies('token'),
+				params: { id: '1' },
+				request: mockRequest({}),
+			} as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('DELETE /api/items/[id]', () => {
+	it('returns 200 on successful delete', async () => {
+		const res = await deleteItemById({ cookies: mockCookies('token'), params: { id: '1' } } as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects without auth', async () => {
+		await expect(
+			deleteItemById({ cookies: mockCookies(), params: { id: '1' } } as any)
+		).rejects.toThrow();
+	});
+});

--- a/site/src/tests/mocks/authenticationRepo.ts
+++ b/site/src/tests/mocks/authenticationRepo.ts
@@ -1,0 +1,12 @@
+import { vi } from 'vitest';
+
+export const defaultAuthResult = { userId: 1, roles: ['admin' as const], name: 'Test User' };
+
+export function createAuthRepoMock(
+	result: { userId: number; roles: string[]; name: string } | null = defaultAuthResult
+) {
+	return {
+		getCredentials: vi.fn().mockResolvedValue(result),
+		register: vi.fn().mockResolvedValue(1),
+	};
+}

--- a/site/src/tests/mocks/env.ts
+++ b/site/src/tests/mocks/env.ts
@@ -1,0 +1,2 @@
+export const VITE_GOOGLE_CLIENT_EMAIL = 'test@example.com';
+export const VITE_GOOGLE_PRIVATE_KEY = 'test-key';

--- a/site/src/tests/mocks/sessionRepo.ts
+++ b/site/src/tests/mocks/sessionRepo.ts
@@ -1,0 +1,16 @@
+import type { UserRole } from '$lib/types/roles';
+import { vi } from 'vitest';
+
+export type MockSession = { userId: number; roles: UserRole[] };
+
+export const adminSession: MockSession = { userId: 1, roles: ['admin'] };
+export const playerSession: MockSession = { userId: 2, roles: ['player'] };
+
+export function createSessionRepoMock(session: MockSession | null = adminSession) {
+	return {
+		getCredentials: vi.fn().mockResolvedValue(session),
+		create: vi.fn().mockResolvedValue('test-token-abc'),
+		delete: vi.fn().mockResolvedValue(undefined),
+		getAll: vi.fn().mockResolvedValue([]),
+	};
+}

--- a/site/src/tests/mocks/sessionRepo.ts
+++ b/site/src/tests/mocks/sessionRepo.ts
@@ -4,7 +4,7 @@ import { vi } from 'vitest';
 export type MockSession = { userId: number; roles: UserRole[] };
 
 export const adminSession: MockSession = { userId: 1, roles: ['admin'] };
-export const playerSession: MockSession = { userId: 2, roles: ['player'] };
+export const playerSession: MockSession = { userId: 2, roles: ['user'] };
 
 export function createSessionRepoMock(session: MockSession | null = adminSession) {
 	return {

--- a/site/src/tests/my/handlers.test.ts
+++ b/site/src/tests/my/handlers.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mockCookies } from '../helpers/mockCookies';
+import { mockRequest } from '../helpers/mockRequest';
+import { createSessionRepoMock, playerSession } from '../mocks/sessionRepo';
+
+const { mockUser, mockCharacter, mockVersion } = vi.hoisted(() => ({
+	mockUser: { id: 1, email: 'player@test.com', name: 'Player One', verified: true },
+	mockCharacter: { id: 1, name: 'Aria', ownerId: 1, ownerName: 'Player One', backstoryUrl: null },
+	mockVersion: { id: 1, characterId: 1, name: 'V1', company: 1, skills: [], items: [], implants: [] },
+}));
+
+vi.mock('$lib/db/session.repo', () => ({ sessionRepo: createSessionRepoMock(playerSession) }));
+vi.mock('$lib/db/user.repo', () => ({
+	userRepo: { getById: vi.fn().mockResolvedValue(mockUser), getByEmail: vi.fn().mockResolvedValue(mockUser) },
+}));
+vi.mock('$lib/db/character.repo', async () => ({
+	characterRepo: {
+		getForUser: vi.fn().mockResolvedValue([mockCharacter]),
+		getByOwner: vi.fn().mockResolvedValue([mockCharacter]),
+		save: vi.fn().mockResolvedValue(1),
+	},
+	isCharacter: (await import('$lib/db/character.repo')).isCharacter,
+	isNewCharacter: (await import('$lib/db/character.repo')).isNewCharacter,
+}));
+vi.mock('$lib/db/character_version.repo', async () => ({
+	characterVersionRepo: {
+		getForUser: vi.fn().mockResolvedValue([mockVersion]),
+		save: vi.fn().mockResolvedValue(1),
+	},
+	isCharacterVersionBare: (await import('$lib/db/character_version.repo')).isCharacterVersionBare,
+}));
+vi.mock('$lib/db/event_participants.repo', () => ({
+	eventParticipantsRepo: {
+		getEventsForCharacters: vi.fn().mockResolvedValue([]),
+		getUserParticipation: vi.fn().mockResolvedValue({ characterId: 1, characterVersionId: 1 }),
+		participate: vi.fn().mockResolvedValue(undefined),
+	},
+}));
+vi.mock('$lib/db/skills.repo', () => ({ skillRepo: { getAll: vi.fn().mockResolvedValue([]) } }));
+vi.mock('$lib/db/items.repo', () => ({ itemRepo: { getAll: vi.fn().mockResolvedValue([]) } }));
+vi.mock('$lib/db/implants.repo', () => ({ implantRepo: { getAll: vi.fn().mockResolvedValue([]) } }));
+vi.mock('$lib/db/companies.repo', () => ({ companyRepo: { getAll: vi.fn().mockResolvedValue([]) } }));
+
+import { GET as getMyUser } from '../../routes/api/my/user/+server';
+import { GET as getMyCharacters } from '../../routes/api/my/characters/+server';
+import { GET as getMyCharactersWithEvents } from '../../routes/api/my/characters/with-events/+server';
+import { GET as getMyParticipation, PUT as putMyParticipation } from '../../routes/api/my/events/[eventId]/participants/+server';
+import { sessionRepo } from '$lib/db/session.repo';
+import { eventParticipantsRepo } from '$lib/db/event_participants.repo';
+
+describe('GET /api/my/user', () => {
+	it('returns 200 with the current user', async () => {
+		const res = await getMyUser({ cookies: mockCookies('token') } as any);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body).toHaveProperty('email');
+	});
+
+	it('rejects without auth token', async () => {
+		await expect(getMyUser({ cookies: mockCookies() } as any)).rejects.toThrow();
+	});
+
+	it('rejects with invalid session', async () => {
+		vi.mocked(sessionRepo.getCredentials).mockResolvedValueOnce(null);
+		await expect(getMyUser({ cookies: mockCookies('bad') } as any)).rejects.toThrow();
+	});
+});
+
+describe('GET /api/my/characters', () => {
+	it('returns 200 with the current user\'s characters', async () => {
+		const res = await getMyCharacters({ cookies: mockCookies('token') } as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects without auth', async () => {
+		await expect(getMyCharacters({ cookies: mockCookies() } as any)).rejects.toThrow();
+	});
+});
+
+describe('GET /api/my/characters/with-events', () => {
+	it('returns 200 with characters and their events', async () => {
+		const res = await getMyCharactersWithEvents({ cookies: mockCookies('token') } as any);
+		expect(res.status).toBe(200);
+	});
+});
+
+describe('GET /api/my/events/[eventId]/participants', () => {
+	it('returns 200 with participation when found', async () => {
+		const res = await getMyParticipation({
+			cookies: mockCookies('token'),
+			params: { eventId: '1' },
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('returns 204 when not registered', async () => {
+		vi.mocked(eventParticipantsRepo.getUserParticipation).mockResolvedValueOnce(undefined);
+		const res = await getMyParticipation({
+			cookies: mockCookies('token'),
+			params: { eventId: '1' },
+		} as any);
+		expect(res.status).toBe(204);
+	});
+
+	it('rejects without auth', async () => {
+		await expect(
+			getMyParticipation({ cookies: mockCookies(), params: { eventId: '1' } } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('PUT /api/my/events/[eventId]/participants', () => {
+	const validBody = {
+		id: null,
+		name: 'Aria',
+		ownerId: 1,
+		ownerName: 'Player One',
+		versions: [mockVersion],
+	};
+
+	it('returns 200 for valid registration body', async () => {
+		const res = await putMyParticipation({
+			cookies: mockCookies('token'),
+			params: { eventId: '1' },
+			request: mockRequest(validBody),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		await expect(
+			putMyParticipation({
+				cookies: mockCookies('token'),
+				params: { eventId: '1' },
+				request: mockRequest({}),
+			} as any)
+		).rejects.toThrow();
+	});
+
+	it('rejects without auth', async () => {
+		await expect(
+			putMyParticipation({
+				cookies: mockCookies(),
+				params: { eventId: '1' },
+				request: mockRequest(validBody),
+			} as any)
+		).rejects.toThrow();
+	});
+});

--- a/site/src/tests/sessions/handlers.test.ts
+++ b/site/src/tests/sessions/handlers.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mockCookies } from '../helpers/mockCookies';
+import { mockRequest } from '../helpers/mockRequest';
+import { createSessionRepoMock, adminSession } from '../mocks/sessionRepo';
+
+const mockNewSession = {
+	userId: 1,
+	roles: ['user' as const],
+	end: null,
+	description: 'test session',
+};
+
+vi.mock('$lib/db/session.repo', async () => ({
+	sessionRepo: createSessionRepoMock(),
+	isNewSession: (await import('$lib/db/session.repo')).isNewSession,
+}));
+
+import { GET as getSessions, POST as postSession } from '../../routes/api/sessions/+server';
+import { DELETE as deleteSession } from '../../routes/api/sessions/[token]/+server';
+import { sessionRepo } from '$lib/db/session.repo';
+
+describe('GET /api/sessions', () => {
+	it('returns 200 with sessions list for admin', async () => {
+		const res = await getSessions({
+			request: new Request('http://localhost'),
+			cookies: mockCookies('token'),
+		} as any);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(Array.isArray(body)).toBe(true);
+	});
+
+	it('rejects without auth token', async () => {
+		await expect(
+			getSessions({ request: new Request('http://localhost'), cookies: mockCookies() } as any)
+		).rejects.toThrow();
+	});
+
+	it('rejects with invalid session', async () => {
+		vi.mocked(sessionRepo.getCredentials).mockResolvedValueOnce(null);
+		await expect(
+			getSessions({ request: new Request('http://localhost'), cookies: mockCookies('bad') } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('POST /api/sessions', () => {
+	it('returns 200 with new token for valid body', async () => {
+		const res = await postSession({
+			cookies: mockCookies('token'),
+			request: mockRequest(mockNewSession),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		await expect(
+			postSession({
+				cookies: mockCookies('token'),
+				request: mockRequest({ invalid: true }),
+			} as any)
+		).rejects.toThrow();
+	});
+
+	it('rejects without auth', async () => {
+		await expect(
+			postSession({
+				cookies: mockCookies(),
+				request: mockRequest(mockNewSession),
+			} as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('DELETE /api/sessions/[token]', () => {
+	it('returns 200 on successful deletion', async () => {
+		const res = await deleteSession({ cookies: mockCookies('token'), params: { token: 'some-token' } } as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects without auth', async () => {
+		await expect(
+			deleteSession({ cookies: mockCookies(), params: { token: 'some-token' } } as any)
+		).rejects.toThrow();
+	});
+});

--- a/site/src/tests/skills/handlers.test.ts
+++ b/site/src/tests/skills/handlers.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mockCookies } from '../helpers/mockCookies';
+import { mockRequest } from '../helpers/mockRequest';
+import { createSessionRepoMock } from '../mocks/sessionRepo';
+
+const { mockSkill, mockGroup } = vi.hoisted(() => ({
+	mockSkill: { id: 1, name: 'Slash', description: 'A slash attack', groupId: 1, groupName: 'Combat' },
+	mockGroup: { id: 1, name: 'Combat', description: 'Combat skills' },
+}));
+
+vi.mock('$lib/db/session.repo', () => ({ sessionRepo: createSessionRepoMock() }));
+vi.mock('$lib/db/skills.repo', async () => ({
+	skillRepo: {
+		getAll: vi.fn().mockResolvedValue([mockSkill]),
+		getWithId: vi.fn().mockResolvedValue(mockSkill),
+		save: vi.fn().mockResolvedValue(1),
+		delete: vi.fn().mockResolvedValue(undefined),
+		getAllGroups: vi.fn().mockResolvedValue([mockGroup]),
+		getGroupWithId: vi.fn().mockResolvedValue(mockGroup),
+		saveSkillGroup: vi.fn().mockResolvedValue(1),
+		deleteSkillGroup: vi.fn().mockResolvedValue(undefined),
+	},
+	isSkill: (await import('$lib/db/skills.repo')).isSkill,
+	isSkillGroup: (await import('$lib/db/skills.repo')).isSkillGroup,
+}));
+
+import { GET as getSkills, PUT as putSkill } from '../../routes/api/skills/+server';
+import { GET as getSkillById, POST as postSkillById, DELETE as deleteSkillById } from '../../routes/api/skills/[id]/+server';
+import { GET as getGroups, PUT as putGroup } from '../../routes/api/skills/groups/+server';
+import { GET as getGroupById, POST as postGroupById, DELETE as deleteGroupById } from '../../routes/api/skills/groups/[id]/+server';
+import { sessionRepo } from '$lib/db/session.repo';
+import { skillRepo } from '$lib/db/skills.repo';
+
+describe('GET /api/skills', () => {
+	it('returns 200 with skills list for admin', async () => {
+		const res = await getSkills({ cookies: mockCookies('token') } as any);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(Array.isArray(body)).toBe(true);
+	});
+
+	it('rejects without auth token', async () => {
+		await expect(getSkills({ cookies: mockCookies() } as any)).rejects.toThrow();
+	});
+
+	it('rejects with invalid session', async () => {
+		vi.mocked(sessionRepo.getCredentials).mockResolvedValueOnce(null);
+		await expect(getSkills({ cookies: mockCookies('bad') } as any)).rejects.toThrow();
+	});
+});
+
+describe('PUT /api/skills', () => {
+	it('returns 200 for a valid skill body', async () => {
+		const res = await putSkill({
+			cookies: mockCookies('token'),
+			request: mockRequest(mockSkill),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body with BadRequest', async () => {
+		await expect(
+			putSkill({ cookies: mockCookies('token'), request: mockRequest({}) } as any)
+		).rejects.toThrow();
+	});
+
+	it('rejects without auth', async () => {
+		await expect(
+			putSkill({ cookies: mockCookies(), request: mockRequest(mockSkill) } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('GET /api/skills/[id]', () => {
+	it('returns 200 with skill when found', async () => {
+		const res = await getSkillById({ cookies: mockCookies('token'), params: { id: '1' } } as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects with NotFoundRequest when skill not found', async () => {
+		vi.mocked(skillRepo.getWithId).mockResolvedValueOnce(null);
+		await expect(
+			getSkillById({ cookies: mockCookies('token'), params: { id: '999' } } as any)
+		).rejects.toThrow();
+	});
+
+	it('rejects without auth', async () => {
+		await expect(getSkillById({ cookies: mockCookies(), params: { id: '1' } } as any)).rejects.toThrow();
+	});
+});
+
+describe('POST /api/skills/[id]', () => {
+	it('returns 200 for a valid skill update', async () => {
+		const res = await postSkillById({
+			cookies: mockCookies('token'),
+			params: { id: '1' },
+			request: mockRequest(mockSkill),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		await expect(
+			postSkillById({
+				cookies: mockCookies('token'),
+				params: { id: '1' },
+				request: mockRequest({}),
+			} as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('DELETE /api/skills/[id]', () => {
+	it('returns 200 on successful delete', async () => {
+		const res = await deleteSkillById({ cookies: mockCookies('token'), params: { id: '1' } } as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects without auth', async () => {
+		await expect(
+			deleteSkillById({ cookies: mockCookies(), params: { id: '1' } } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('GET /api/skills/groups', () => {
+	it('returns 200 with groups list', async () => {
+		const res = await getGroups({ cookies: mockCookies('token') } as any);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(Array.isArray(body)).toBe(true);
+	});
+
+	it('rejects without auth', async () => {
+		await expect(getGroups({ cookies: mockCookies() } as any)).rejects.toThrow();
+	});
+});
+
+describe('PUT /api/skills/groups', () => {
+	it('returns 200 for a valid skill group', async () => {
+		const res = await putGroup({
+			cookies: mockCookies('token'),
+			request: mockRequest(mockGroup),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		await expect(
+			putGroup({ cookies: mockCookies('token'), request: mockRequest({}) } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('GET /api/skills/groups/[id]', () => {
+	it('returns 200 when group found', async () => {
+		const res = await getGroupById({ cookies: mockCookies('token'), params: { id: '1' } } as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects when group not found', async () => {
+		vi.mocked(skillRepo.getGroupWithId).mockResolvedValueOnce(null);
+		await expect(
+			getGroupById({ cookies: mockCookies('token'), params: { id: '999' } } as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('POST /api/skills/groups/[id]', () => {
+	it('returns 200 for a valid update', async () => {
+		const res = await postGroupById({
+			cookies: mockCookies('token'),
+			params: { id: '1' },
+			request: mockRequest(mockGroup),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		await expect(
+			postGroupById({
+				cookies: mockCookies('token'),
+				params: { id: '1' },
+				request: mockRequest({}),
+			} as any)
+		).rejects.toThrow();
+	});
+});
+
+describe('DELETE /api/skills/groups/[id]', () => {
+	it('returns 200 on successful delete', async () => {
+		const res = await deleteGroupById({ cookies: mockCookies('token'), params: { id: '1' } } as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects without auth', async () => {
+		await expect(
+			deleteGroupById({ cookies: mockCookies(), params: { id: '1' } } as any)
+		).rejects.toThrow();
+	});
+});

--- a/site/src/tests/skills/validators.test.ts
+++ b/site/src/tests/skills/validators.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { isSkill, isSkillGroup } from '$lib/db/skills.repo';
+
+describe('isSkill', () => {
+	it('returns false for null', () => {
+		expect(isSkill(null)).toBe(false);
+	});
+
+	it('returns false for an empty object', () => {
+		expect(isSkill({})).toBe(false);
+	});
+
+	it('returns false when id has wrong type', () => {
+		expect(isSkill({ id: '1', name: 'Slash', description: 'A slash attack', groupId: 1, groupName: 'Combat' })).toBe(false);
+	});
+
+	it('returns false when groupId is missing', () => {
+		expect(isSkill({ id: 1, name: 'Slash', description: 'A slash attack', groupName: 'Combat' })).toBe(false);
+	});
+
+	it('returns true for a valid skill with numeric id', () => {
+		expect(isSkill({ id: 1, name: 'Slash', description: 'A slash attack', groupId: 1, groupName: 'Combat' })).toBe(true);
+	});
+
+	it('returns true for a new skill with null id', () => {
+		expect(isSkill({ id: null, name: 'Slash', description: 'A slash attack', groupId: 1, groupName: 'Combat' })).toBe(true);
+	});
+});
+
+describe('isSkillGroup', () => {
+	it('returns false for null', () => {
+		expect(isSkillGroup(null)).toBe(false);
+	});
+
+	it('returns false for an empty object', () => {
+		expect(isSkillGroup({})).toBe(false);
+	});
+
+	it('returns false when name is missing', () => {
+		expect(isSkillGroup({ id: 1, description: 'Combat skills' })).toBe(false);
+	});
+
+	it('returns true for a valid skill group', () => {
+		expect(isSkillGroup({ id: 1, name: 'Combat', description: 'Combat skills' })).toBe(true);
+	});
+
+	it('returns true for a new skill group with null id', () => {
+		expect(isSkillGroup({ id: null, name: 'Combat', description: 'Combat skills' })).toBe(true);
+	});
+});

--- a/site/src/tests/users/handlers.test.ts
+++ b/site/src/tests/users/handlers.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mockCookies } from '../helpers/mockCookies';
+import { mockRequest } from '../helpers/mockRequest';
+import { createSessionRepoMock } from '../mocks/sessionRepo';
+
+const { mockUser } = vi.hoisted(() => ({
+	mockUser: { id: 1, email: 'test@test.com', name: 'Test User', verified: true },
+}));
+
+vi.mock('$lib/db/session.repo', () => ({ sessionRepo: createSessionRepoMock() }));
+vi.mock('$lib/db/user.repo', async () => ({
+	userRepo: {
+		getAll: vi.fn().mockResolvedValue([mockUser]),
+		getById: vi.fn().mockResolvedValue(mockUser),
+		update: vi.fn().mockResolvedValue(undefined),
+	},
+	isUser: (await import('$lib/db/user.repo')).isUser,
+}));
+
+import { GET as getUsers } from '../../routes/api/users/+server';
+import { GET as getUserById, POST as postUserById } from '../../routes/api/users/[id]/+server';
+import { sessionRepo } from '$lib/db/session.repo';
+
+describe('GET /api/users', () => {
+	it('returns 200 with users list for admin', async () => {
+		const res = await getUsers({ cookies: mockCookies('token') } as any);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(Array.isArray(body)).toBe(true);
+	});
+
+	it('rejects without auth token', async () => {
+		await expect(getUsers({ cookies: mockCookies() } as any)).rejects.toThrow();
+	});
+
+	it('rejects with invalid session', async () => {
+		vi.mocked(sessionRepo.getCredentials).mockResolvedValueOnce(null);
+		await expect(getUsers({ cookies: mockCookies('bad') } as any)).rejects.toThrow();
+	});
+});
+
+describe('GET /api/users/[id]', () => {
+	it('returns 200 with user when found', async () => {
+		const res = await getUserById({ cookies: mockCookies('token'), params: { id: '1' } } as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects without auth', async () => {
+		await expect(getUserById({ cookies: mockCookies(), params: { id: '1' } } as any)).rejects.toThrow();
+	});
+});
+
+describe('POST /api/users/[id]', () => {
+	it('returns 200 for a valid user update', async () => {
+		const res = await postUserById({
+			cookies: mockCookies('token'),
+			params: { id: '1' },
+			request: mockRequest(mockUser),
+		} as any);
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects invalid body', async () => {
+		await expect(
+			postUserById({
+				cookies: mockCookies('token'),
+				params: { id: '1' },
+				request: mockRequest({ email: 'no-id@test.com' }),
+			} as any)
+		).rejects.toThrow();
+	});
+
+	it('rejects without auth', async () => {
+		await expect(
+			postUserById({
+				cookies: mockCookies(),
+				params: { id: '1' },
+				request: mockRequest(mockUser),
+			} as any)
+		).rejects.toThrow();
+	});
+});

--- a/site/vitest.config.ts
+++ b/site/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+	resolve: {
+		alias: {
+			$lib: resolve('./src/lib'),
+		},
+	},
+	test: {
+		include: ['src/**/*.{test,spec}.{js,ts}'],
+		environment: 'node',
+		globals: true,
+	},
+});

--- a/site/vitest.config.ts
+++ b/site/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			$lib: resolve('./src/lib'),
+			'$env/static/private': resolve('./src/tests/mocks/env.ts'),
 		},
 	},
 	test: {


### PR DESCRIPTION
## Summary\n\n- Install and configure Vitest as the test runner for the site package\n- Add shared test utilities (mockCookies, mockRequest) and reusable repo mocks\n- 154 Vitest tests covering all 13 API endpoint domains: authentication, characters, companies, email-templates, events, implants, items, my, sessions, skills, users\n\nCloses #48\nCloses #49\nCloses #50\nCloses #51\nCloses #52\nCloses #53\nCloses #54

---
_Generated by [Claude Code](https://claude.ai/code/session_011zwy3ePQZSnApTc6Rr9cBQ)_